### PR TITLE
Fix to convert an uppercase file extension of picture upload to lowercase

### DIFF
--- a/middleware/multer.js
+++ b/middleware/multer.js
@@ -4,7 +4,7 @@ const path = require("path");
 module.exports = multer({
   storage: multer.diskStorage({}),
   fileFilter: (req, file, cb) => {
-    let ext = path.extname(file.originalname);
+    let ext = path.extname(file.originalname).toLowerCase();
     if (ext !== ".jpg" && ext !== ".jpeg" && ext !== ".png") {
       cb(new Error("File type is not supported"), false);
       return;


### PR DESCRIPTION
I ran into a situation where a picture I wanted to upload was rejected due to the file extension not being in lowercase.   Rascal_Two and I diagnosed the problem together on his stream and added this solution.